### PR TITLE
Refactor PageContentContext for efficiency

### DIFF
--- a/src/XperienceCommunity.DataContext/PageContentContext.cs
+++ b/src/XperienceCommunity.DataContext/PageContentContext.cs
@@ -23,7 +23,7 @@ namespace XperienceCommunity.DataContext
         private int? _linkedItemsDepth;
         private (int?, int?) _offset;
         private PathMatch? _pathMatch;
-        private IList<string>? _columnNames;
+        private HashSet<string>? _columnNames;
         private IQueryable<T>? _query;
 
         public PageContentContext(IProgressiveCache cache, PageContentQueryExecutor<T> pageContentQueryExecutor,
@@ -156,12 +156,7 @@ namespace XperienceCommunity.DataContext
         [return: NotNull]
         public IDataContext<T> WithColumns(params string[] columnNames)
         {
-            _columnNames ??= new List<string>(columnNames.Length);
-
-            foreach (var column in columnNames)
-            {
-                _columnNames.Add(column);
-            }
+            _columnNames ??= [.. columnNames];
 
             return this;
         }


### PR DESCRIPTION
- Changed the data structure for storing column names in the PageContentContext class from IList<string> to HashSet<string> to prevent duplicates and improve lookup performance.
- Simplified the WithColumns method implementation by utilizing the HashSet collection initializer, making the code more concise and leveraging the characteristics of the new data structure.