### PR TITLE
Refactor query executors and update guidelines

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,33 @@
+# Copilot Instructions
+
+- Use latest syntax compatible with **.NET 8**.
+- Adhere to [Microsoft's coding conventions for C#](https://docs.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions).
+- Include XML documentation comments for all public classes, methods, and properties.
+- Use **PascalCase** for type and method names, **camelCase** for local variables and parameters.
+- Optimize code for readability, maintainability, and performance.
+- Azure Functions should target the latest Azure Function tooling, and target .NET 8.
+- Follow **SOLID** principles and clean architecture patterns.
+
+# Team Best Practices
+- Prefer full method bodies over inline lambdas in C#.
+- Prefer async and await over synchronous code. [Async Guidance](https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AsyncGuidance.md)
+- Prefer var over explicit types.
+- Employ dependency injection using the built-in DI container.
+- Handle exceptions gracefully and use `Microsoft.Extensions.Logging` for logging.
+- Follow HttpClient Best Guidance [HttpClient Guidance](https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/HttpClientGuidance.md)
+
+## Testing Guidelnes
+- Use the AAA paattern (Arrange, Act, Assert)
+- Avoid infrastructure dependencies.
+- Name tests clearly.
+- Write minimally passing tests.
+- Avoid magic strings.
+- Avoid logic in tests.
+- Prefer helper methods for setup and teardown.
+- Avoid multiple acts in a single test.
+- Write unit tests using **xUnit** and aim for high code coverage.
+
+## Project-specific instructions
+
+- Utilize **ASP.NET Core** for building web applications and APIs.[ASP.NET Core Guidance](https://github.com/davidfowl/AspNetCoreDiagnosticScenarios/blob/master/AspNetCoreGuidance.md)
+- Utilize Xperience by Kentico API for database interactions if applicable.

--- a/src/XperienceCommunity.DataContext/BaseContentQueryExecutor.cs
+++ b/src/XperienceCommunity.DataContext/BaseContentQueryExecutor.cs
@@ -1,0 +1,38 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using CMS.ContentEngine;
+
+namespace XperienceCommunity.DataContext
+{
+    /// <summary>
+    /// Abstract base class for executing content queries.
+    /// </summary>
+    /// <typeparam name="T">The type of content item to be returned by the query.</typeparam>
+    public abstract class BaseContentQueryExecutor<T>
+    {
+        /// <summary>
+        /// Gets the content query executor.
+        /// </summary>
+        protected IContentQueryExecutor QueryExecutor { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BaseContentQueryExecutor{T}"/> class.
+        /// </summary>
+        /// <param name="queryExecutor">The content query executor.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="queryExecutor"/> is null.</exception>
+        protected BaseContentQueryExecutor(IContentQueryExecutor queryExecutor)
+        {
+            QueryExecutor = queryExecutor ?? throw new ArgumentNullException(nameof(queryExecutor));
+        }
+
+        /// <summary>
+        /// Executes the content query asynchronously.
+        /// </summary>
+        /// <param name="queryBuilder">The content item query builder.</param>
+        /// <param name="queryOptions">The content query execution options.</param>
+        /// <param name="cancellationToken">The cancellation token.</param>
+        /// <returns>A task that represents the asynchronous operation. The task result contains an enumerable of content items.</returns>
+        [return: NotNull]
+        public abstract Task<IEnumerable<T>> ExecuteQueryAsync(ContentItemQueryBuilder queryBuilder,
+            ContentQueryExecutionOptions queryOptions, CancellationToken cancellationToken);
+    }
+}

--- a/src/XperienceCommunity.DataContext/PageContentQueryExecutor.cs
+++ b/src/XperienceCommunity.DataContext/PageContentQueryExecutor.cs
@@ -7,31 +7,29 @@ using XperienceCommunity.DataContext.Interfaces;
 
 namespace XperienceCommunity.DataContext
 {
-    public sealed class PageContentQueryExecutor<T> where T : class, IWebPageFieldsSource, new()
+    public sealed class PageContentQueryExecutor<T> : BaseContentQueryExecutor<T> where T : class, IWebPageFieldsSource, new()
     {
         private readonly ILogger<PageContentQueryExecutor<T>> _logger;
         private readonly ImmutableList<IPageContentProcessor<T>>? _processors;
-        private readonly IContentQueryExecutor _queryExecutor;
 
         public PageContentQueryExecutor(ILogger<PageContentQueryExecutor<T>> logger,
-            IContentQueryExecutor queryExecutor, IEnumerable<IPageContentProcessor<T>>? processors)
+            IContentQueryExecutor queryExecutor, IEnumerable<IPageContentProcessor<T>>? processors) : base(queryExecutor)
         {
             ArgumentNullException.ThrowIfNull(logger);
             ArgumentNullException.ThrowIfNull(queryExecutor);
             _logger = logger;
-            _queryExecutor = queryExecutor;
             _processors = processors?.ToImmutableList();
         }
 
         [return: NotNull]
-        public async Task<IEnumerable<T>> ExecuteQueryAsync(ContentItemQueryBuilder queryBuilder,
+        public override async Task<IEnumerable<T>> ExecuteQueryAsync(ContentItemQueryBuilder queryBuilder,
             ContentQueryExecutionOptions queryOptions, CancellationToken cancellationToken)
         {
             try
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var results = await _queryExecutor.GetMappedWebPageResult<T>(queryBuilder, queryOptions,
+                var results = await QueryExecutor.GetMappedWebPageResult<T>(queryBuilder, queryOptions,
                     cancellationToken: cancellationToken);
 
                 if (_processors == null)

--- a/src/XperienceCommunity.DataContext/ReusableSchemaExecutor.cs
+++ b/src/XperienceCommunity.DataContext/ReusableSchemaExecutor.cs
@@ -4,28 +4,25 @@ using Microsoft.Extensions.Logging;
 
 namespace XperienceCommunity.DataContext
 {
-    public sealed class ReusableSchemaExecutor<T>
+    public sealed class ReusableSchemaExecutor<T> : BaseContentQueryExecutor<T>
     {
         private readonly ILogger<ReusableSchemaExecutor<T>> _logger;
-        private readonly IContentQueryExecutor _queryExecutor;
 
-        public ReusableSchemaExecutor(ILogger<ReusableSchemaExecutor<T>> logger, IContentQueryExecutor queryExecutor)
+        public ReusableSchemaExecutor(ILogger<ReusableSchemaExecutor<T>> logger, IContentQueryExecutor queryExecutor) : base(queryExecutor)
         {
             ArgumentNullException.ThrowIfNull(logger);
-            ArgumentNullException.ThrowIfNull(queryExecutor);
             _logger = logger;
-            _queryExecutor = queryExecutor;
         }
 
         [return: NotNull]
-        public async Task<IEnumerable<T>> ExecuteQueryAsync(ContentItemQueryBuilder queryBuilder,
+        public override async Task<IEnumerable<T>> ExecuteQueryAsync(ContentItemQueryBuilder queryBuilder,
             ContentQueryExecutionOptions queryOptions, CancellationToken cancellationToken)
         {
             try
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var results = await _queryExecutor.GetMappedResult<T>(queryBuilder, queryOptions,
+                var results = await QueryExecutor.GetMappedResult<T>(queryBuilder, queryOptions,
                     cancellationToken: cancellationToken);
 
                 return results ?? [];


### PR DESCRIPTION
Updated `copilot-instructions.md` with new .NET 8 syntax guidelines, coding conventions, and best practices. Introduced `BaseContentQueryExecutor<T>` abstract class for executing content queries. Refactored `ContentQueryExecutor<T>`, `PageContentQueryExecutor<T>`, and `ReusableSchemaExecutor<T>` to inherit from the new base class, promoting code reuse and adherence to updated guidelines.