### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,6 +3,9 @@
 
 name: .NET
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/brandonhenricks/xperience-community-data-context/security/code-scanning/2](https://github.com/brandonhenricks/xperience-community-data-context/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only performs read operations (e.g., checking out code and restoring dependencies), the `contents: read` permission is sufficient. This block should be added at the root level of the workflow to apply to all jobs, as none of the jobs require additional permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
