### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Nuget Release
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/brandonhenricks/xperience-community-data-context/security/code-scanning/1](https://github.com/brandonhenricks/xperience-community-data-context/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's steps, it primarily needs read access to repository contents and write access to pull requests (if applicable). Since the workflow pushes a package to NuGet, no additional permissions are required for repository operations.

The `permissions` block will be added after the `name` field and before the `on` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
