### PR TITLE
Refactor IReusableSchemaContext for improved type safety

### DIFF
--- a/src/XperienceCommunity.DataContext/Abstractions/IReusableSchemaContext.cs
+++ b/src/XperienceCommunity.DataContext/Abstractions/IReusableSchemaContext.cs
@@ -10,11 +10,11 @@ public interface IReusableSchemaContext<T> : IDataContext<T>
     /// Specifies that the data context should include content type fields.
     /// </summary>
     /// <returns>The data context with content type fields included.</returns>
-    IDataContext<T> WithContentTypeFields();
+    IReusableSchemaContext<T> WithContentTypeFields();
 
     /// <summary>
     /// Specifies that the data context should include web page data.
     /// </summary>
     /// <returns>The data context with web page data included.</returns>
-    IDataContext<T> WithWebPageData();
+    IReusableSchemaContext<T> WithWebPageData();
 }

--- a/src/XperienceCommunity.DataContext/Contexts/ReusableSchemaContext.cs
+++ b/src/XperienceCommunity.DataContext/Contexts/ReusableSchemaContext.cs
@@ -39,7 +39,7 @@ public sealed class ReusableSchemaContext<T> : BaseDataContext<T, ReusableSchema
 
     /// <inheritdoc />
     [return: NotNull]
-    public IDataContext<T> WithContentTypeFields()
+    public IReusableSchemaContext<T> WithContentTypeFields()
     {
         _withContentFields = true;
         return this;
@@ -47,7 +47,7 @@ public sealed class ReusableSchemaContext<T> : BaseDataContext<T, ReusableSchema
 
 
     [return: NotNull]
-    public IDataContext<T> WithWebPageData()
+    public IReusableSchemaContext<T> WithWebPageData()
     {
         _withPageData = true;
         return this;


### PR DESCRIPTION
Update methods to return IReusableSchemaContext<T> instead of IDataContext<T> for better type safety and clarity in the interface.